### PR TITLE
Resolving writting permission issue

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,8 @@
+# Change with the value indicated with the command `id` (check for uid=<yourUID>)
+UID=1000 
+# Change with the value indicated with the command `id` (check for gid=<yourGID>)
+GID=1000 
+
 BASE_PROTOCOL="https"  # do not change to http, unless you know how to fix traefik labels
 
 HTTP_PORT=80

--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,3 @@
-# Change with the value indicated by the command `id` results (check for uid=<yourUID>)
-UID=1000 
-# Change with the value indicated by the command `id` results (check for gid=<yourGID>)
-GID=1000 
 
 BASE_PROTOCOL="https"  # do not change to http, unless you know how to fix traefik labels
 
@@ -12,6 +8,9 @@ HOST="localhost"
 HOSTPORT="${HOST}"  # set to ${HOST}:${HTTPS_PORT} if HTTPS_PORT is different from 443
 
 ACME_EMAIL=""  # required for valid https certificates
+
+UID=1000 # Change with the value returned by the command `id -u`
+GID=1000 # Change with the value returned by the command `id -g`
 
 GEONATURE_SUPERGRANT_ARGS="--group --nom Grp_admin"  # comment this line to disable supergrant
 

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
-# Change with the value indicated with the command `id` (check for uid=<yourUID>)
+# Change with the value indicated by the command `id` results (check for uid=<yourUID>)
 UID=1000 
-# Change with the value indicated with the command `id` (check for gid=<yourGID>)
+# Change with the value indicated by the command `id` results (check for gid=<yourGID>)
 GID=1000 
 
 BASE_PROTOCOL="https"  # do not change to http, unless you know how to fix traefik labels

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ De plus, celui-ci fournit une image Docker de GeoNature contenant, outre les mod
 - [Dashboard](https://github.com/PnX-SI/gn_module_dashboard)
 - [Monitorings](https://github.com/PnX-SI/gn_module_monitorings)
 
-
 ## Démarrage rapide
 
 - Installer Docker : [voir la documentation](https://docs.docker.com/engine/install/)
@@ -16,7 +15,7 @@ De plus, celui-ci fournit une image Docker de GeoNature contenant, outre les mod
 - Installer `git` (`sudo apt-get install git`)
 - Clôner le dépôt : `git clone https://github.com/PnX-SI/GeoNature-Docker-services` ou extraire une [archive](https://github.com/PnX-SI/GeoNature-Docker-services/releases)
 - Se placer dans le répertoire du dépôt : `cd GeoNature-Docker-services`
-- Créer le fichier `.env` à partir du fichier d’exemple : `cp .env.sample .env`. Compléter les paramètres importants (`HOST`, `ACME_EMAIL`, `GEONATURE_LOCAL_SRID`, `POSTGRES_PASSWORD`).
+- Créer le fichier `.env` à partir du fichier d’exemple : `cp .env.sample .env`. Compléter les paramètres importants (`HOST`, `ACME_EMAIL`, `GEONATURE_LOCAL_SRID`, `POSTGRES_PASSWORD`, `GID`, `UID`).
 - Lancer la commande `./init-config.sh` afin de créer les fichiers de configuration suivants, avec des clés secrètes générées aléatoirement :
   - `config/geonature/geonature_config.toml`
   - `config/usershub/config.py`
@@ -25,17 +24,16 @@ De plus, celui-ci fournit une image Docker de GeoNature contenant, outre les mod
 
 Les logs sont accessibles avec la commande `docker compose logs -f` ou `docker compose -f <nom du service>` (avec l'option `-n100` pour ne renvoyer que les 100 dernières lignes des logs).
 
-
 ## Les services
 
- - `postgres` : la base de données
- - `usershub` : la gestion des utilisateurs
- - `taxhub` : la gestion du référentiel taxonomique
- - `geonature-backend` : l’API de GeoNature
- - `geonature-frontend` : l’interface web de GeoNature
- - `geonature-worker` : exécution de certaines tâches de GeoNature en arrière-plan (import, export, mail, etc...)
- - `redis` : service de communication entre le worker et le backend
- - `traefik` : serveur web redirigeant les requêtes vers le bon service
+- `postgres` : la base de données
+- `usershub` : la gestion des utilisateurs
+- `taxhub` : la gestion du référentiel taxonomique
+- `geonature-backend` : l’API de GeoNature
+- `geonature-frontend` : l’interface web de GeoNature
+- `geonature-worker` : exécution de certaines tâches de GeoNature en arrière-plan (import, export, mail, etc...)
+- `redis` : service de communication entre le worker et le backend
+- `traefik` : serveur web redirigeant les requêtes vers le bon service
 
 ```
 SERVICE              PORTS
@@ -51,7 +49,6 @@ usershub             5001/tcp
 
 ![Schéma des services](docs/schema_services_0.1.png)
 
-
 ## Configuration
 
 Voir la documentation des différentes applications pour renseigner les fichiers de configuration :
@@ -60,7 +57,7 @@ Voir la documentation des différentes applications pour renseigner les fichiers
 - UsersHub : `./config/usershub/config.py` ([fichier d’exemple](https://github.com/PnX-SI/UsersHub/tree/master/config/config.py.sample))
 - TaxHub : `./config/taxhub/config.py` ([fichier d’exemple](https://github.com/PnX-SI/TaxHub/apptax/config.py.sample))
 
-Ces fichiers doivent contenir *a minima* le paramètre `SECRET_KEY`.  
+Ces fichiers doivent contenir _a minima_ le paramètre `SECRET_KEY`.  
 Vous pouvez générer automatiquement des fichiers vierges contenant des clés secrètes aléatoires avec le script `./init-config.sh`.
 
 Si vous modifiez les fichiers de configuration de GeoNature, d'un de ses modules, de TaxHub ou de UsersHub, vous devez relancer les conteneurs Docker avec la commande `docker compose restart` (ou idéalement seulement le conteneur concerné, par exemple `docker compose restart usershub`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 x-defaults: &defaults
-  user: ${UID:-1000}:${GID:-1000}
+  user: ${UID}:${GID}
 
 x-env-defaults: &env-defaults
   http_proxy: ${HTTP_PROXY:-}


### PR DESCRIPTION
Dans certains cas, le conteneur docker n'a pas les permissions d'écriture. Par conséquent, les utilisateurs ne peuvent pas uploader d'images (ou d'autres médias) dans Taxhub ou Geonature. Une solution consiste à changer les variables d'environnement `GID` et `UID`. Il a été proposé d'indiquer celle-ci directement dans le fichier `.env`.