### PR TITLE
fix(README): clarify for logs and correct for --tail option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ De plus, celui-ci fournit une image Docker de GeoNature contenant, outre les mod
   - `config/taxhub/config.py`
 - Lancer les conteneurs : `docker compose up -d`
 
-Les logs sont accessibles avec la commande `docker compose logs -f` ou `docker compose -f <nom du service>` (avec l'option `-n100` pour ne renvoyer que les 100 dernières lignes des logs).
+Les logs de tous les services sont accessibles avec la commande `docker compose logs -f`.
+Pour n'afficher que les 100 dernières lignes, on utilise l'option `--tail 100` et donc la commande `docker compose logs -f --tail 100`.
+Pour n'afficher les logs que d'un service en particulier, on utilise la commande `docker compose logs -f <nom du service>`.
+
 
 ## Les services
 


### PR DESCRIPTION
- Clarify: split documentation of CLI logs for Docker services into three distinct parts 
  - basic command to log all lines, 
  - command with tail option to log only a certain number of lines from the end, 
  - command to log lines for a specific service only
 
- Correct: `--tail` option, which works, rather than `-n` option which is not recognized