### PR TITLE
Versions Compatibilities

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,10 @@ HTTPS_PORT=443
 HOST="localhost"
 HOSTPORT="${HOST}"  # set to ${HOST}:${HTTPS_PORT} if HTTPS_PORT is different from 443
 
+GEONATURE_VERSION=2.13.4
+TAXHUB_VERSION=1.12.1
+USERSHUB_VERSION=2.3.4
+
 ACME_EMAIL=""  # required for valid https certificates
 
 UID=1000 # Change with the value returned by the command `id -u`
@@ -28,26 +32,26 @@ POSTGRES_PASSWORD="geonatpasswd"
 POSTGRES_HOST="postgres"
 POSTGRES_DB="geonature2db"
 
-USERSHUB_IMAGE="ghcr.io/pnx-si/usershub:latest"
+USERSHUB_IMAGE="ghcr.io/pnx-si/usershub:${USERSHUB_VERSION}"
 USERSHUB_PROTOCOL="${BASE_PROTOCOL}"
 USERSHUB_HOST="${HOST}"
 USERSHUB_HOSTPORT="${HOSTPORT}"
 USERSHUB_PREFIX="/usershub"
 
-TAXHUB_IMAGE="ghcr.io/pnx-si/taxhub:latest"
+TAXHUB_IMAGE="ghcr.io/pnx-si/taxhub:${TAXHUB_VERSION}"
 TAXHUB_PROTOCOL="${BASE_PROTOCOL}"
 TAXHUB_HOST="${HOST}"
 TAXHUB_HOSTPORT="${HOSTPORT}"
 TAXHUB_PREFIX="/taxhub"
 TAXHUB_API_PREFIX="${TAXHUB_PREFIX}/api"
 
-GEONATURE_BACKEND_EXTRA_IMAGE="ghcr.io/pnx-si/geonature-backend-extra:latest"
+GEONATURE_BACKEND_EXTRA_IMAGE="ghcr.io/pnx-si/geonature-backend-extra:${GEONATURE_VERSION}"
 GEONATURE_BACKEND_PROTOCOL="${BASE_PROTOCOL}"
 GEONATURE_BACKEND_HOST="${HOST}"
 GEONATURE_BACKEND_HOSTPORT="${HOSTPORT}"
 GEONATURE_BACKEND_PREFIX="/geonature/api"
 
-GEONATURE_FRONTEND_EXTRA_IMAGE="ghcr.io/pnx-si/geonature-frontend-extra:latest"
+GEONATURE_FRONTEND_EXTRA_IMAGE="ghcr.io/pnx-si/geonature-frontend-extra:${GEONATURE_VERSION}"
 GEONATURE_FRONTEND_PROTOCOL="${BASE_PROTOCOL}"
 GEONATURE_FRONTEND_HOST="${HOST}"
 GEONATURE_FRONTEND_HOSTPORT="${HOSTPORT}"


### PR DESCRIPTION
This PR address the compatibility between version of GeoNature and its dependency Taxhub, UsersHub. This PR propose to set the versions of GeoNature, TaxHub, UsersHub in the `.env` file next to their images addresses .