### PR TITLE
chore(compose): remove useless `:ro` on docker.sock for traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - "--certificatesResolvers.acme-resolver.acme.storage=/etc/traefik/certs/acme.json"
       - "--certificatesResolvers.acme-resolver.acme.tlsChallenge=true"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./config/traefik:/etc/traefik/dynamic
       - ./data/traefik/certs:/etc/traefik/certs
     ports:


### PR DESCRIPTION
Having `:ro` on the mounted volume `/var/run/docker.sock` in service `traefik` does not work and is actually useless.