### PR TITLE
Release 2.15.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GEONATURE_BACKEND_IMAGE=ghcr.io/pnx-si/geonature-backend:2.15.2
+          build-args: GEONATURE_BACKEND_IMAGE=ghcr.io/pnx-si/geonature-backend:${{github.ref_name}}
 
   frontend:
     name: Build geonature frontend docker image
@@ -92,4 +92,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GEONATURE_FRONTEND_IMAGE=ghcr.io/pnx-si/geonature-frontend:2.15.2
+          build-args: GEONATURE_FRONTEND_IMAGE=ghcr.io/pnx-si/geonature-frontend:${{github.ref_name}}


### PR DESCRIPTION
This PR prepare the release of the 2.15.3 version of GeoNature-Docker-services. 

A novelty: now GeoNature backend extra image publishing does not need to change the version in GHAction file (`docker.yml`). Instead, we use the `github.ref_name` that contains the tag version

Therefore, GDS release from now on depends only updating the extra gn modules !