### PR TITLE
Fix ownership in dev

### DIFF
--- a/build/dev/Dockerfile-geonature-backend
+++ b/build/dev/Dockerfile-geonature-backend
@@ -7,9 +7,10 @@ ARG GID=1000
 
 WORKDIR /dist/geonature
 
-RUN echo "Creating user geonature with UID: ${UID}, GID: ${GID}" && \
-    groupadd -g ${GID} geonature && \
-    useradd -m -u ${UID} -g geonature geonature
+RUN if echo "Creating user geonature with UID: ${UID}, GID: ${GID}" && groupadd -g ${GID} geonature && \
+    useradd -m -u ${UID} -g geonature geonature; then echo "Created user geonature"; \
+    else echo "User or group geonature already exists, continuing"; \
+    fi
 
 RUN rm -f geonature-*
 

--- a/build/dev/Dockerfile-geonature-backend
+++ b/build/dev/Dockerfile-geonature-backend
@@ -10,11 +10,12 @@ COPY --chown=${UID}:${GUID} /sources/gn_module_export /sources/gn_module_export
 COPY --chown=${UID}:${GUID} /sources/gn_module_dashboard /sources/gn_module_dashboard
 COPY --chown=${UID}:${GUID} /sources/gn_module_monitoring /sources/gn_module_monitoring
 RUN --mount=type=cache,target=/root/.cache \
-    pip install *.whl sentry_sdk[flask] \
+    pip install *.whl sentry_sdk[flask]
+    
 # Delete when those dependency will be added to requirements-dev
 RUN pip install watchdog pytest pytest-flask pytest-benchmark pip-tools
 RUN cd /sources/GeoNature/backend
 RUN pip install -r requirements-dev.txt
 RUN --mount=type=cache,target=/root/.cache \
-    pip install -e /sources/GeoNature -e /sources/gn_module_export -e /sources/gn_module_dashboard -e /sources/gn_module_monitoring \
+    pip install -e /sources/GeoNature -e /sources/gn_module_export -e /sources/gn_module_dashboard -e /sources/gn_module_monitoring
 RUN rm -f *.whl

--- a/build/dev/Dockerfile-geonature-backend
+++ b/build/dev/Dockerfile-geonature-backend
@@ -5,10 +5,10 @@ FROM ${GEONATURE_BACKEND_IMAGE}-wheels AS base_env
 WORKDIR /dist/geonature
 
 RUN rm -f geonature-*
-COPY --chown=${UID}:${GUID} /sources/GeoNature /sources/GeoNature
-COPY --chown=${UID}:${GUID} /sources/gn_module_export /sources/gn_module_export
-COPY --chown=${UID}:${GUID} /sources/gn_module_dashboard /sources/gn_module_dashboard
-COPY --chown=${UID}:${GUID} /sources/gn_module_monitoring /sources/gn_module_monitoring
+COPY --chown=${UID}:${GID} /sources/GeoNature /sources/GeoNature
+COPY --chown=${UID}:${GID} /sources/gn_module_export /sources/gn_module_export
+COPY --chown=${UID}:${GID} /sources/gn_module_dashboard /sources/gn_module_dashboard
+COPY --chown=${UID}:${GID} /sources/gn_module_monitoring /sources/gn_module_monitoring
 RUN --mount=type=cache,target=/root/.cache \
     pip install *.whl sentry_sdk[flask]
     

--- a/build/dev/Dockerfile-geonature-backend
+++ b/build/dev/Dockerfile-geonature-backend
@@ -1,10 +1,18 @@
 ARG GEONATURE_BACKEND_IMAGE="ghcr.io/pnx-si/geonature-backend-local:latest"
 
-
 FROM ${GEONATURE_BACKEND_IMAGE}-wheels AS base_env
+
+ARG UID=1000
+ARG GID=1000
+
 WORKDIR /dist/geonature
 
+RUN echo "Creating user geonature with UID: ${UID}, GID: ${GID}" && \
+    groupadd -g ${GID} geonature && \
+    useradd -m -u ${UID} -g geonature geonature
+
 RUN rm -f geonature-*
+
 COPY --chown=${UID}:${GID} /sources/GeoNature /sources/GeoNature
 COPY --chown=${UID}:${GID} /sources/gn_module_export /sources/gn_module_export
 COPY --chown=${UID}:${GID} /sources/gn_module_dashboard /sources/gn_module_dashboard
@@ -19,3 +27,5 @@ RUN pip install -r requirements-dev.txt
 RUN --mount=type=cache,target=/root/.cache \
     pip install -e /sources/GeoNature -e /sources/gn_module_export -e /sources/gn_module_dashboard -e /sources/gn_module_monitoring
 RUN rm -f *.whl
+
+USER geonature

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -40,6 +40,9 @@ services:
         condition: service_completed_successfully
     build:
       dockerfile: build/dev/Dockerfile-geonature-backend
+      args:
+        UID: ${UID}
+        GID: ${GID}
     volumes:
       - ./sources/GeoNature:/sources/GeoNature
 
@@ -54,6 +57,9 @@ services:
       - ./sources/gn_module_monitoring:/sources/gn_module_monitoring
     build:
       dockerfile: build/dev/Dockerfile-geonature-backend
+      args:
+        UID: ${UID}
+        GID: ${GID}
 
   geonature-worker:
     depends_on:


### PR DESCRIPTION
les variables UID et GID ne sont pas utilisées lors du build, par manque absence de déclaration en `ARG` dans le dockerfile.

Cette PR force la modif de ces variables au build du mode dev via leur déclaration dans les blocs `args` du docker-compose et du Dockerfile dédiés au dev.

Je propose également de déclarer un utilisateur geonature avec ces UID/GID dans les conteneurs du backend, plus propre de mon avis (je vous laisse décider de son maintien ou de son retrait).