### PR TITLE
fix(readme): fix two text errors in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ qui est fait dans le Makefile, par exemple pour lancer cypress en headed et en s
 `source .env; cd sources/GeoNature/frontend; API_ENDPOINT="https://$${HOST}$${GEONATURE_BACKEND_PREFIX}/" URL_APPLICATION="https:$${HOST}$${GEONATURE_FRONTEND_PREFIX}/" cypress run --headed --spec cypress/e2e/occtax-form-spec.js`
 
 
-## <a name="dev-faq"></a> FAQ de developpement
+## <a name="dev-faq"></a> FAQ de développement
 
 * Mon docker compose de dev ne lance pas le build des images et essaye de les chercher sur un repo à la place.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ qui est fait dans le Makefile, par exemple pour lancer cypress en headed et en s
 `source .env; cd sources/GeoNature/frontend; API_ENDPOINT="https://$${HOST}$${GEONATURE_BACKEND_PREFIX}/" URL_APPLICATION="https:$${HOST}$${GEONATURE_FRONTEND_PREFIX}/" cypress run --headed --spec cypress/e2e/occtax-form-spec.js`
 
 
-## <a name="dev"></a> FAQ de developpement
+## <a name="dev-faq"></a> FAQ de developpement
 
 * Mon docker compose de dev ne lance pas le build des images et essaye de les chercher sur un repo à la place.
 


### PR DESCRIPTION
Two fixes for section `FAQ de développement`:
- Fix anchor from `dev` to `dev-faq` : https://github.com/PnX-SI/GeoNature-Docker-services/pull/66/commits/6150fb9b700115f11d0e09d8bff66e1daa9d403f
- Fix typographic from `developpement` to `développement` : https://github.com/PnX-SI/GeoNature-Docker-services/pull/66/commits/1ccccff23ecd37c842e3d043396e1fc2520208ab