### PR TITLE
fix(makefile): rectify url for api endpoint in frontend config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ launch:
 dev_init:
 	./init-config.sh
 	jq '.projects.geonature.architect.build.configurations.development += {"baseHref": "/geonature/"}' sources/GeoNature/frontend/angular.json > angular.json.tmp && mv angular.json.tmp sources/GeoNature/frontend/angular.json # Pas une super pratique mais pas d'autre solution pour le moment
-	source .env; echo "{\"API_ENDPOINT\":\"//$${HOSTPORT}$${GEONATURE_BACKEND_PREFIX}\"}" > sources/GeoNature/frontend/src/assets/config.json
+	source .env; echo "{\"API_ENDPOINT\":\"//$${GEONATURE_BACKEND_HOSTPORT}$${GEONATURE_BACKEND_PREFIX}\"}" > sources/GeoNature/frontend/src/assets/config.json
 
 submodule_init:
 	# So the config is right even for a fork


### PR DESCRIPTION
Properly handles cases where a port other than the default is configured for `geonature-backend` (variable `GEONATURE_BACKEND_HOSTPORT`) but not for other services (variable `HOSTPORT`).