### PR TITLE
chore: dev auto install GN dependencies

### DIFF
--- a/build/Dockerfile-geonature-frontend
+++ b/build/Dockerfile-geonature-frontend
@@ -23,7 +23,6 @@ WORKDIR /build
 RUN npm link @angular/cli
 COPY ./build/dev/frontend_entrypoint.sh /entrypoint.sh
 ENTRYPOINT /entrypoint.sh
-RUN npm install
 EXPOSE 80
 
 FROM source-extra AS build-extra

--- a/build/dev/Dockerfile-geonature-backend
+++ b/build/dev/Dockerfile-geonature-backend
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.6
 
 ARG GEONATURE_BACKEND_IMAGE="ghcr.io/pnx-si/geonature-backend-local:latest"
-FROM ${GEONATURE_BACKEND_IMAGE}-wheels AS base_env
+FROM ${GEONATURE_BACKEND_IMAGE}-dev
 
 ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
@@ -15,25 +15,13 @@ RUN if echo "Creating user geonature with UID: ${UID}, GID: ${GID}" && groupadd 
 
 RUN rm -f geonature-*
 
-COPY --chown=${DOCKER_UID}:${DOCKER_GUID} /sources/GeoNature /sources/GeoNature
-COPY --chown=${DOCKER_UID}:${DOCKER_GUID} /sources /sources
-
-RUN --mount=type=cache,target=/root/.cache \
-    pip install *.whl sentry_sdk[flask]
+COPY --chown=${DOCKER_UID}:${DOCKER_GUID} sources/GeoNature/backend/requirements-dev.txt .
 
 # Delete when those dependency will be added to requirements-dev
-RUN pip install watchdog pytest pytest-flask pytest-benchmark pip-tools
-RUN cd /sources/GeoNature/backend && pip install -r requirements-dev.txt
+RUN pip install uv
+RUN --mount=type=cache,target=/root/.cache  uv pip install --system watchdog pytest pytest-flask pytest-benchmark pip-tools
 
-RUN --mount=type=cache,target=/root/.cache \
-    pip install -e /sources/GeoNature && \
-    for module in $(ls -d /sources/gn_*/ | sort); do \
-        [ -d "$module" ] && pip install -e "$module"; \
-    done
 COPY --chmod=755 /build/dev/backend_entrypoint.sh /dev_entrypoint.sh
 ENTRYPOINT ["/dev_entrypoint.sh"]
-
-# Nettoyage final
-RUN rm -f *.whl
 
 USER geonature

--- a/build/dev/backend_entrypoint.sh
+++ b/build/dev/backend_entrypoint.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-if [ "${GEONATURE_SKIP_POPULATE_DB}" != "true" ]; then
-    echo "Modules to install: $(ls -d /sources/gn_*/ | sort)"
-    for module in $(ls -d /sources/gn_*/ | sort); do
-        [ -d "$module" ] && pip install -e "$module"
-    done
-fi
+echo "Modules to install: $(ls -d /sources/gn_*/ | sort)"
+for module in $(ls -d /sources/gn_*/ | sort); do
+    [ -d "$module" ] && pip install -e "$module"
+done
+echo "Dependencies to install: $(ls -d /sources/GeoNature/backend/dependencies/* | sort)"
+for dependencies in $(ls -d /sources/GeoNature/backend/dependencies/* | sort); do
+    [ -d "$dependencies" ] && pip install -e "$dependencies"
+done
 
 . /entrypoint.sh

--- a/build/dev/backend_entrypoint.sh
+++ b/build/dev/backend_entrypoint.sh
@@ -8,5 +8,8 @@ echo "Dependencies to install: $(ls -d /sources/GeoNature/backend/dependencies/*
 for dependencies in $(ls -d /sources/GeoNature/backend/dependencies/* | sort); do
     [ -d "$dependencies" ] && pip install -e "$dependencies"
 done
-
+echo "Contribs to install: $(ls -d /sources/GeoNature/backend/dependencies/* | sort)"
+for contrib in $(ls -d /sources/GeoNature/contrib/* | sort); do
+    [ -d "$contrib" ] && pip install -e "$contrib"
+done
 . /entrypoint.sh

--- a/build/dev/backend_entrypoint.sh
+++ b/build/dev/backend_entrypoint.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
+cd /sources/GeoNature/backend && uv pip install --system -r requirements-dev.txt
+
 echo "Modules to install: $(ls -d /sources/gn_*/ | sort)"
 for module in $(ls -d /sources/gn_*/ | sort); do
-    [ -d "$module" ] && pip install -e "$module"
+    [ -d "$module" ] && uv pip install --system -e "$module"
 done
-echo "Dependencies to install: $(ls -d /sources/GeoNature/backend/dependencies/* | sort)"
-for dependencies in $(ls -d /sources/GeoNature/backend/dependencies/* | sort); do
-    [ -d "$dependencies" ] && pip install -e "$dependencies"
-done
-echo "Contribs to install: $(ls -d /sources/GeoNature/backend/dependencies/* | sort)"
+echo "Contribs to install: $(ls -d /sources/GeoNature/contrib/* | sort)"
 for contrib in $(ls -d /sources/GeoNature/contrib/* | sort); do
-    [ -d "$contrib" ] && pip install -e "$contrib"
+    [ -d "$contrib" ] && uv pip install --system -e "$contrib"
 done
 . /entrypoint.sh

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,6 +43,7 @@ services:
     volumes:
       - ./sources:/sources
       - ./build/dev/backend_entrypoint.sh:/dev_entrypoint.sh
+    entrypoint: ["/dev_entrypoint.sh"]
     build:
       dockerfile: build/dev/Dockerfile-geonature-backend
       args:
@@ -68,11 +69,14 @@ services:
 
   geonature-worker:
     image: ${GEONATURE_BACKEND_EXTRA_IMAGE}
+    user: root:root
     depends_on:
       base-backend:
         condition: service_completed_successfully
     volumes:
       - ./sources:/sources
+      - ./build/dev/backend_entrypoint.sh:/dev_entrypoint.sh
+    entrypoint: ["/dev_entrypoint.sh"]
     build:
       dockerfile: build/dev/Dockerfile-geonature-backend
       args:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,11 +2,11 @@ services:
 
   #------------------------------------Builds section start-----------------------------------#
   base-backend:
-    image: ${GEONATURE_BACKEND_IMAGE}-wheels
+    image: ${GEONATURE_BACKEND_IMAGE}-dev
     build:
       context: sources/GeoNature
       dockerfile: backend/Dockerfile
-      target: wheels
+      target: dev
     entrypoint: /bin/bash -c exit
 
   base-frontend-source:


### PR DESCRIPTION
Before, in dev mode, if a modification occurred in GeoNature dependencies (for instance usershub-authentication-module), it wasn't taken into account in docker. You needed to rebuild it. But for the modules under /sources (like dashboard or monitorings), you didn't need to rebuild it. 

This PR makes GN dependencies works as other modules to keep consistency. It also makes it easier to works on dependencies. 