### PR TITLE
feat(alti): add one-shot altitude raster loader for post-install

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,7 @@ COMPOSE_PROFILES=db,usershub
 GEONATURE_DB_LOCAL_SRID=2154  # [MUST CHANGE] This define the
 POSTGRES_USER="geonatadmin"
 POSTGRES_PASSWORD="geonatadmin" # [MUST CHANGE] it is also default password for pre-built db
+POSTGRES_IMAGE=postgis/postgis:15-3.4 
 
 BASE_PROTOCOL="https"  # Do not change to http if you use traefik. Change to http if you use only the `essential.yml` docker compose file.
 POSTGRES_HOST="postgres"  # If you don't use compose db you will need to change that
@@ -90,3 +91,18 @@ GEONATURE_URL_APPLICATION="${GEONATURE_FRONTEND_PROTOCOL}://${GEONATURE_FRONTEND
 
 ## Should be set to false for first launch if you use base db but can be set to true afterward to gain time.
 # SKIP_POPULATE_DB=false
+
+#--------------------------------------------------------#
+## POSTGRES BDD - INSERT ALTITUDE
+# active / désactive l'import
+IMPORT_ALTI=false
+
+# source & cible
+ALTI_URL=https://geonature.fr/data/ign/BDALTIV2_2-0_250M_ASC_LAMB93-IGN69_FRANCE_2017-06-21.zip
+ALTI_SCHEMA=ref_geo
+ALTI_TABLE=dem
+# SRID local (2154 = LAMB93)
+ALTI_SRID=2154
+ALTI_REINDEX=false
+ALTI_REINDEX_CONCURRENTLY=false
+#--------------------------------------------------------#

--- a/README.md
+++ b/README.md
@@ -152,6 +152,48 @@ Ces variables d’environnement doivent être renseignées directement dans le f
 
 - Lancez la commande qui va télécharger les dernières versions des différentes applications et les relancer : `docker compose pull && docker compose up -d --remove-orphans`
 
+## Importer les altitudes après installation de la base
+
+Le service `alti-loader` permet d'importer un raster d'altitude dans PostGIS après l'installation initiale de la base. Il s'exécute comme un service one-shot via `compose-utils.yml`.
+
+### Variables à configurer
+
+Les variables suivantes peuvent être renseignées dans le fichier `.env` ou dans les fichiers d'exemple de `env_examples/` :
+
+- `POSTGRES_IMAGE` : image PostGIS utilisée pour construire `alti-loader`. Cette valeur doit rester alignée avec l'image réellement utilisée par la base.
+- `IMPORT_ALTI` : active l'import. La valeur par défaut recommandée est `false` afin d'éviter un import involontaire.
+- `ALTI_URL` : archive ZIP contenant le raster ASCII à importer.
+- `ALTI_SCHEMA` : schéma cible dans PostgreSQL.
+- `ALTI_TABLE` : table cible créée ou recréée par l'import.
+- `ALTI_SRID` : SRID du raster source.
+- `ALTI_REINDEX` : laisser `false` par défaut. Cette option ne sert qu'à relancer explicitement un `REINDEX` de l'index raster après import.
+- `ALTI_REINDEX_CONCURRENTLY` : laisser `false` par défaut. Cette option n'a d'intérêt que si un `REINDEX` est demandé et qu'il faut limiter le verrouillage sur une base déjà en service.
+
+Dans le cas d'une base externe, il faut aussi adapter les variables de connexion suivantes :
+
+- `POSTGRES_HOST`
+- `POSTGRES_PORT`
+- `POSTGRES_DB`
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD_RAW`
+- `POSTGRES_IMAGE`
+
+### Lancer le service
+
+En mode standard :
+
+```bash
+COMPOSE_FILE=essential.yml:compose-utils.yml docker compose --profile alti-raster run --rm alti-loader
+```
+
+En mode développement :
+
+```bash
+COMPOSE_FILE=essential.yml:traefik-http.yml:dev.yml:compose-utils.yml docker compose --profile alti-raster run --rm alti-loader
+```
+
+Le service télécharge l'archive définie par `ALTI_URL`, importe le premier fichier `.asc` trouvé dans `${ALTI_SCHEMA}.${ALTI_TABLE}`, puis s'arrête. Si `ALTI_REINDEX=true`, un `REINDEX` optionnel est exécuté à la fin.
+
 ## FAQ
 
 Pour en savoir plus (lancer des commandes `geonature`, accéder à la BDD, intégrer le MNT, modifier votre domaine,...), consultez la [FAQ GeoNature-Docker-services](/docs/faq.md).

--- a/assets/alti-loader/Dockerfile
+++ b/assets/alti-loader/Dockerfile
@@ -1,0 +1,14 @@
+# ./assets/alti-loader/Dockerfile
+ARG POSTGIS_IMAGE=postgis/postgis:15-3.4
+FROM ${POSTGIS_IMAGE}
+
+# Ajout des dépendances nécessaires
+RUN apt-get update -qq && \
+    apt-get install -y -qq curl unzip postgis && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copie du script d'import
+COPY alti-loader.sh /usr/local/bin/alti-loader.sh
+RUN chmod +x /usr/local/bin/alti-loader.sh
+
+ENTRYPOINT ["bash", "/usr/local/bin/alti-loader.sh"]

--- a/assets/alti-loader/alti-loader.sh
+++ b/assets/alti-loader/alti-loader.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Valeurs par défaut si non passées par l'env
+: "${IMPORT_ALTI:=false}"
+: "${ALTI_URL:=https://geonature.fr/data/ign/BDALTIV2_2-0_250M_ASC_LAMB93-IGN69_FRANCE_2017-06-21.zip}"
+: "${ALTI_SCHEMA:=ref_geo}"
+: "${ALTI_TABLE:=dem}"
+: "${ALTI_SRID:=2154}"
+
+if [ "${IMPORT_ALTI}" != "true" ]; then
+  echo "[alti-loader] IMPORT_ALTI != true, rien à faire."
+  exit 0
+fi
+
+
+echo "[alti-loader] Préparation…"
+mkdir -p /work /tmp/alti
+cd /work
+
+URL="${ALTI_URL}"
+FILE="$(basename "$URL")"
+
+if [ ! -f "$FILE" ]; then
+  echo "[alti-loader] Téléchargement $URL…"
+  curl -L "$URL" -o "$FILE"
+else
+  echo "[alti-loader] Zip déjà présent, on réutilise: $FILE"
+fi
+
+echo "[alti-loader] Décompression…"
+rm -rf /tmp/alti/*
+unzip -o "$FILE" -d /tmp/alti >/dev/null
+
+ASC_PATH="$(find /tmp/alti -type f -name "*.asc" | head -n1)"
+if [ -z "${ASC_PATH}" ]; then
+  echo "[alti-loader] ERREUR: aucun .asc trouvé."
+  exit 1
+fi
+echo "[alti-loader] ASC: $ASC_PATH"
+
+
+echo "[alti-loader] Import raster → ${ALTI_SCHEMA}.${ALTI_TABLE} (SRID=${ALTI_SRID})…"
+#Ajuste -t si besoin (carrelage). 5x5 peut être très fragmenté.
+raster2pgsql -s "${ALTI_SRID}" -c -C -I -M -d -t 5x5 \
+  "${ASC_PATH}" "${ALTI_SCHEMA}.${ALTI_TABLE}" \
+  | PGPASSWORD="${POSTGRES_PASSWORD}" psql \
+      -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+      -U "${POSTGRES_USER}" -d "${POSTGRES_DB}"
+
+# --- REINDEX optionnel ---------------------------------------------------------
+if [ "${ALTI_REINDEX:-false}" = "true" ]; then
+  echo "[alti-loader] REINDEX de l’index de convex hull…"
+  IDX_NAME="${ALTI_SCHEMA}.${ALTI_TABLE}_st_convexhull_idx"
+
+  # Teste l'existence de l'index (retourne 't' ou 'f')
+    EXISTS="$(
+    PGPASSWORD="${POSTGRES_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+        -At -c "SELECT to_regclass('${IDX_NAME}') IS NOT NULL;"
+    )"
+
+
+  if [ "${EXISTS}" = "t" ]; then
+    if [ "${ALTI_REINDEX_CONCURRENTLY:-false}" = "true" ]; then
+      # CONCURRENTLY interdit dans une transaction implicite -> commande dédiée
+      PGPASSWORD="${POSTGRES_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+        -v ON_ERROR_STOP=1 \
+        -c "REINDEX INDEX CONCURRENTLY ${IDX_NAME};"
+    else
+      PGPASSWORD="${POSTGRES_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+        -v ON_ERROR_STOP=1 \
+        -c "REINDEX INDEX ${IDX_NAME};"
+    fi
+    echo "[alti-loader] REINDEX OK."
+  else
+    echo "[alti-loader] Index ${IDX_NAME} introuvable (peut-être pas d’option -I à l’import ?)."
+  fi
+fi
+# ------------------------------------------------------------------------------
+
+echo "[alti-loader] Terminé ✔"

--- a/compose-utils.yml
+++ b/compose-utils.yml
@@ -1,0 +1,25 @@
+services:
+  alti-loader:
+    build:
+      context: ./assets/alti-loader
+      dockerfile: Dockerfile
+      args:
+        POSTGIS_IMAGE: ${POSTGRES_IMAGE:-postgis/postgis:15-3.4}
+    image: custom/alti-loader:latest
+    profiles: ["alti-raster"]
+    user: root
+    environment:
+      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD_RAW}
+      IMPORT_ALTI: ${IMPORT_ALTI:-false}
+      ALTI_URL: ${ALTI_URL:-https://geonature.fr/data/ign/BDALTIV2_2-0_250M_ASC_LAMB93-IGN69_FRANCE_2017-06-21.zip}
+      ALTI_SCHEMA: ${ALTI_SCHEMA:-ref_geo}
+      ALTI_TABLE: ${ALTI_TABLE:-dem}
+      ALTI_SRID: ${ALTI_SRID:-2154}
+      ALTI_REINDEX: ${ALTI_REINDEX:-false}
+      ALTI_REINDEX_CONCURRENTLY: ${ALTI_REINDEX_CONCURRENTLY:-false}
+    networks:
+      - gn   

--- a/env_examples/.env.sample.development
+++ b/env_examples/.env.sample.development
@@ -1,0 +1,97 @@
+# Development environment (local HTTP via Traefik)
+
+# Compose
+COMPOSE_PROJECT_NAME="geonature_integ" # Change according to name project (used to prefix container, volume, network)
+COMPOSE_FILE=essential.yml:traefik-http.yml:dev.yml
+# Add compose-utils.yml only when running one-shot utilities (monitoring install, etc.)
+# Example:
+# COMPOSE_FILE=essential.yml:traefik-http.yml:dev.yml:compose-utils.yml
+COMPOSE_PROFILES=db,usershub
+
+# Database
+GEONATURE_DB_LOCAL_SRID=2154
+POSTGRES_USER=geonatadmin
+POSTGRES_PASSWORD=geonatadmin # To change (# This one need to be without special character , uri encoding)
+POSTGRES_PASSWORD_RAW=xxxxxx # This one need to be with special character
+POSTGRES_HOST=postgres
+POSTGRES_DB=geonature2db
+POSTGRES_PORT_ON_HOST=5433 # Change based on the available port on the local machine
+POSTGRES_PORT=5432
+POSTGRES_IMAGE=postgis/postgis:15-3.4 # Keep aligned with the actual database image; also used to build alti-loader
+
+# URLs seen by the browser in dev
+BASE_PROTOCOL=http
+HOST=localhost
+HTTP_PORT=8888 # Change based on the available port on the local machine
+HTTPS_PORT=443
+HOSTPORT=${HOST}:${HTTP_PORT}
+
+# Traefik dashboard auth (escape $ as $$; no quotes)
+TRAEFIK_USER=admin
+TRAEFIK_PASSWORD=$$apr1$$3ggsV2uT$$Lwf4f6lGcCR9FHcZIMtY/1 # To change
+TRAEFIK_PORT_ON_HOST=8081  # Change based on the available port on the local machine
+TRAEFIK_ACTIVATE_ACCESS_LOG=true
+
+# Docker user mapping
+DOCKER_UID=1000  # [MUST CHANGE] Set this variable using the following command : id -u
+DOCKER_GID=1000  # [MUST CHANGE] Set this variable using the following command : id -g
+
+# App routing
+USERSHUB_PROTOCOL=${BASE_PROTOCOL}
+USERSHUB_PREFIX=/usershub
+USERSHUB_HOST=${HOST}
+USERSHUB_HOSTPORT=${HOSTPORT}
+
+GEONATURE_BACKEND_PROTOCOL=${BASE_PROTOCOL}
+GEONATURE_BACKEND_PREFIX=/geonature/api
+GEONATURE_BACKEND_HOST=${HOST}
+GEONATURE_BACKEND_HOSTPORT=${HOSTPORT}
+
+GEONATURE_FRONTEND_PROTOCOL=${BASE_PROTOCOL}
+GEONATURE_FRONTEND_PREFIX=/geonature
+GEONATURE_FRONTEND_HOST=${HOST}
+GEONATURE_FRONTEND_HOSTPORT=${HOSTPORT}
+
+# Derived URLs
+GEONATURE_API_ENDPOINT=${GEONATURE_BACKEND_PROTOCOL}://${GEONATURE_BACKEND_HOSTPORT}${GEONATURE_BACKEND_PREFIX}
+GEONATURE_URL_APPLICATION=${GEONATURE_FRONTEND_PROTOCOL}://${GEONATURE_FRONTEND_HOSTPORT}${GEONATURE_FRONTEND_PREFIX}
+
+# Volumes and network
+NETWORK_NAME=geonature_network_dev # Change to match the project being launched
+GEONATURE_CONFIG_DIR=./config
+GEONATURE_DATA_DIR=./data
+
+# DB install options
+GEONATURE_DB_ADD_SAMPLE_DATA=false
+GEONATURE_DB_INSTALL_BDC_STATUTS=true
+GEONATURE_DB_INSTALL_SIG_LAYERS=true
+GEONATURE_DB_INSTALL_GRID_LAYER=true
+GEONATURE_DB_INSTALL_REF_SENSITIVITY=true
+GEONATURE_DB_INSTALL_USERSHUB_SAMPLES=true
+GEONATURE_DB_INSTALL_TAXHUB_SAMPLES=true
+
+# Dev images (used by dev.yml builds)
+USERSHUB_IMAGE=localhost/usershub-local:latest
+GEONATURE_BACKEND_IMAGE=localhost/geonature-backend-local:latest
+GEONATURE_BACKEND_EXTRA_IMAGE=localhost/geonature-backend-extra-local:latest
+GEONATURE_FRONTEND_IMAGE=localhost/geonature-frontend-local:latest
+GEONATURE_FRONTEND_EXTRA_IMAGE=localhost/geonature-frontend-extra-local:latest
+GEONATURE_PRE_BUILT_DB=ghcr.io/pnx-si/geonature-db-extra:latest
+
+## Should be set to false for first launch if you use base db but can be set to true afterward to gain time.
+# SKIP_POPULATE_DB=false
+
+#--------------------------------------------------------#
+## POSTGRES BDD - INSERT ALTITUDE
+# active / désactive l'import
+IMPORT_ALTI=false
+
+# source & cible
+ALTI_URL=https://geonature.fr/data/ign/BDALTIV2_2-0_250M_ASC_LAMB93-IGN69_FRANCE_2017-06-21.zip
+ALTI_SCHEMA=ref_geo
+ALTI_TABLE=dem
+# SRID local (2154 = LAMB93)
+ALTI_SRID=2154
+ALTI_REINDEX=false
+ALTI_REINDEX_CONCURRENTLY=false
+#--------------------------------------------------------#

--- a/env_examples/.env.sample.prod
+++ b/env_examples/.env.sample.prod
@@ -1,0 +1,114 @@
+# Production environment (often behind HAProxy / a load balancer)
+
+# Compose
+# Use traefik-http.yml when TLS is terminated upstream (HAProxy / LB).
+# Use traefik.yml when Traefik itself must handle TLS and ACME certificates.
+COMPOSE_PROJECT_NAME="geonature_integ" # Change according to name project (used to prefix container, volume, network)
+COMPOSE_FILE=essential.yml:traefik-http.yml
+# Add compose-utils.yml only when running one-shot utilities (monitoring install, etc.)
+# Example:
+# COMPOSE_FILE=essential.yml:traefik-http.yml:compose-utils.yml
+COMPOSE_PROFILES=db,usershub
+
+# Database
+GEONATURE_DB_LOCAL_SRID=2154
+POSTGRES_USER=geonatadmin
+POSTGRES_PASSWORD=geonatadmin # To change (# This one need to be without special character , uri encoding)
+POSTGRES_PASSWORD_RAW=xxxxxx # This one need to be with special character
+POSTGRES_HOST=postgres
+POSTGRES_DB=geonature2db
+POSTGRES_PORT_ON_HOST=5433 # Change based on the available port on the local machine
+POSTGRES_PORT=5432
+POSTGRES_IMAGE=postgis/postgis:15-3.4 # Keep aligned with the actual database image; also used to build alti-loader
+
+# Public URLs seen by the browser
+# BASE_PROTOCOL is the PUBLIC scheme. Keep https if HAProxy/LB terminates TLS.
+# Set to http only if users really access the site over plain HTTP.
+BASE_PROTOCOL=https
+# Public domain name used by Traefik Host(...) rules and generated URLs.
+HOST=example.app.fr
+# HTTP_PORT is where Traefik listens on the host (often internal only).
+# If HAProxy forwards to Traefik on 8092, set HTTP_PORT=8092 here.
+HTTP_PORT=8092
+# HTTPS_PORT is only used when Traefik handles TLS itself.
+HTTPS_PORT=443
+# HOSTPORT must reflect the PUBLIC host[:port] used by browsers.
+# Behind HAProxy/LB, do not include the internal Traefik port here.
+HOSTPORT=${HOST}
+
+# Traefik dashboard auth (escape $ as $$; no quotes)
+TRAEFIK_USER=admin
+TRAEFIK_PASSWORD=$$apr1$$3ggsV2uT$$Lwf4f6lGcCR9FHcZIMtY/1
+TRAEFIK_PORT_ON_HOST=8081 # Change based on the available port on the local machine
+TRAEFIK_ACTIVATE_ACCESS_LOG=true
+
+# Docker user mapping
+DOCKER_UID=1000 # [MUST CHANGE] Set this variable using the following command : id -u
+DOCKER_GID=1000 # [MUST CHANGE] Set this variable using the following command : id -g
+
+# App routing
+USERSHUB_PROTOCOL=${BASE_PROTOCOL}
+USERSHUB_PREFIX=/usershub
+USERSHUB_HOST=${HOST}
+USERSHUB_HOSTPORT=${HOSTPORT}
+
+GEONATURE_BACKEND_PROTOCOL=${BASE_PROTOCOL}
+GEONATURE_BACKEND_PREFIX=/geonature/api
+GEONATURE_BACKEND_HOST=${HOST}
+GEONATURE_BACKEND_HOSTPORT=${HOSTPORT}
+
+GEONATURE_FRONTEND_PROTOCOL=${BASE_PROTOCOL}
+GEONATURE_FRONTEND_PREFIX=/geonature
+GEONATURE_FRONTEND_HOST=${HOST}
+GEONATURE_FRONTEND_HOSTPORT=${HOSTPORT}
+
+# Derived URLs
+GEONATURE_API_ENDPOINT=${GEONATURE_BACKEND_PROTOCOL}://${GEONATURE_BACKEND_HOSTPORT}${GEONATURE_BACKEND_PREFIX}
+GEONATURE_URL_APPLICATION=${GEONATURE_FRONTEND_PROTOCOL}://${GEONATURE_FRONTEND_HOSTPORT}${GEONATURE_FRONTEND_PREFIX}
+
+# Volumes and network
+# Change NETWORK_NAME per instance to avoid collisions across multiple stacks.
+NETWORK_NAME=geonature_network
+GEONATURE_CONFIG_DIR=./config
+GEONATURE_DATA_DIR=./data
+
+# DB install options
+GEONATURE_DB_ADD_SAMPLE_DATA=false
+GEONATURE_DB_INSTALL_BDC_STATUTS=true
+GEONATURE_DB_INSTALL_SIG_LAYERS=true
+GEONATURE_DB_INSTALL_GRID_LAYER=true
+GEONATURE_DB_INSTALL_REF_SENSITIVITY=true
+GEONATURE_DB_INSTALL_USERSHUB_SAMPLES=true
+GEONATURE_DB_INSTALL_TAXHUB_SAMPLES=true
+
+# Images from registry
+REGISTRY=registry.gitlab.com/<path-to-registry> # Change according to registry url where images are stored
+TAG_BACKEND=0.2.1
+
+GEONATURE_BACKEND_IMAGE="${REGISTRY}${COMPOSE_PROJECT_NAME}__backend:${TAG_BACKEND}"
+GEONATURE_BACKEND_EXTRA_IMAGE="${REGISTRY}${COMPOSE_PROJECT_NAME}__backend-extra:${TAG_BACKEND}"
+
+TAG_FRONTEND=0.2.1
+GEONATURE_FRONTEND_IMAGE="${REGISTRY}${COMPOSE_PROJECT_NAME}__frontend:${TAG_FRONTEND}"
+GEONATURE_FRONTEND_EXTRA_IMAGE="${REGISTRY}${COMPOSE_PROJECT_NAME}__frontend-extra:${TAG_FRONTEND}"
+
+TAG_USERSHUB=0.2.1
+USERSHUB_IMAGE="${REGISTRY}${COMPOSE_PROJECT_NAME}__usershub:${TAG_USERSHUB}"
+
+## Should be set to false for first launch if you use base db but can be set to true afterward to gain time.
+# SKIP_POPULATE_DB=false
+
+#--------------------------------------------------------#
+## POSTGRES BDD - INSERT ALTITUDE
+# active / désactive l'import
+IMPORT_ALTI=false
+
+# source & cible
+ALTI_URL=https://geonature.fr/data/ign/BDALTIV2_2-0_250M_ASC_LAMB93-IGN69_FRANCE_2017-06-21.zip
+ALTI_SCHEMA=ref_geo
+ALTI_TABLE=dem
+# SRID local (2154 = LAMB93)
+ALTI_SRID=2154
+ALTI_REINDEX=false
+ALTI_REINDEX_CONCURRENTLY=false
+#--------------------------------------------------------#


### PR DESCRIPTION
Add a dedicated `alti-loader` one-shot service in `compose-utils.yml` to import a raster altitude dataset into PostGIS after the database has already been installed.

This change adds:
- a dedicated `assets/alti-loader` image and import script
- support for building the loader from `POSTGRES_IMAGE` so it stays aligned with the PostGIS image used by the stack
- environment variables to control the import source, target schema/table, SRID and optional reindex behavior
- documentation and environment samples for both development and production setups
- README instructions explaining how to configure and run the service after database installation

The loader is designed as an explicit one-shot operation:
- `IMPORT_ALTI` defaults to `false` to avoid accidental imports
- `ALTI_REINDEX` defaults to `false` and remains optional
- `ALTI_REINDEX_CONCURRENTLY` defaults to `false` and is only relevant when reindexing is explicitly requested

This also documents the requirement to use `POSTGRES_PASSWORD_RAW` for CLI-based connections and to keep `POSTGRES_IMAGE` aligned with the actual PostGIS image, especially when targeting an external database.


Refs: #71 
Reviewed-by: andriac