### PR TITLE
dépendance de build (compose >= v2.36.2)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -52,13 +52,20 @@ GEONATURE_FRONTEND_PREFIX="/geonature"
 ### BUILD - Uncomment this if you want to build your own production images
 
 # You can personalize names - necessary if you have multiple GeoNature-Docker-services on the same machine.
-# USERSHUB_IMAGE="ghcr.io/pnx-si/usershub-local:latest"
-# GEONATURE_BACKEND_IMAGE="ghcr.io/pnx-si/geonature-backend-local:latest"
-# GEONATURE_BACKEND_EXTRA_IMAGE="ghcr.io/pnx-si/geonature-backend-extra-local:latest"
-# GEONATURE_FRONTEND_IMAGE="ghcr.io/pnx-si/geonature-frontend-local:latest"
-# GEONATURE_FRONTEND_EXTRA_IMAGE="ghcr.io/pnx-si/geonature-frontend-extra-local:latest"
+# USERSHUB_IMAGE="geonature-docker-services-usershub:local"
+# GEONATURE_BACKEND_IMAGE="geonature-docker-services-backend:local"
+# GEONATURE_BACKEND_WHEELS_IMAGE="${GEONATURE_BACKEND_IMAGE}-wheels"
+# GEONATURE_BACKEND_EXTRA_IMAGE="geonature-docker-services-backend-extra:local"
+# GEONATURE_FRONTEND_IMAGE="geonature-docker-services-frontend:local"
+# GEONATURE_FRONTEND_SOURCE_IMAGE="${GEONATURE_FRONTEND_IMAGE}-source"
+# GEONATURE_FRONTEND_NGINX_IMAGE="${GEONATURE_FRONTEND_IMAGE}-nginx"
+# GEONATURE_FRONTEND_IMAGE="geonature-docker-services-frontend:local"
+# GEONATURE_FRONTEND_EXTRA_IMAGE=""geonature-docker-services-frontend-extra:local"
 
 # COMPOSE_FILE=docker-compose.yml:docker-compose-build.yml
+
+# If you have docker compose >= 2.36.2, uncomment this:
+# COMPOSE_FILE=${COMPOSE_FILE}:docker-compose-build-deps.yml
 
 ### DEV CONFIGS  Uncomment if you want to use in dev mode
 

--- a/.env.sample
+++ b/.env.sample
@@ -49,13 +49,20 @@ GEONATURE_FRONTEND_HOST="${HOST}"
 GEONATURE_FRONTEND_HOSTPORT="${HOSTPORT}"
 GEONATURE_FRONTEND_PREFIX="/geonature"
 
-### DEV CONFIGS  Uncomment if you want to use in dev mode
+### BUILD - Uncomment this if you want to build your own production images
+
+# You can personalize names - necessary if you have multiple GeoNature-Docker-services on the same machine.
 # USERSHUB_IMAGE="ghcr.io/pnx-si/usershub-local:latest"
 # GEONATURE_BACKEND_IMAGE="ghcr.io/pnx-si/geonature-backend-local:latest"
 # GEONATURE_BACKEND_EXTRA_IMAGE="ghcr.io/pnx-si/geonature-backend-extra-local:latest"
 # GEONATURE_FRONTEND_IMAGE="ghcr.io/pnx-si/geonature-frontend-local:latest"
 # GEONATURE_FRONTEND_EXTRA_IMAGE="ghcr.io/pnx-si/geonature-frontend-extra-local:latest"
-# COMPOSE_FILE=docker-compose.yml:docker-compose-dev.yml
 
-# Should be set to false for first launch but can be set to true afterward to gain time.
-# SKIP_POPULATE_DB=false
+# COMPOSE_FILE=docker-compose.yml:docker-compose-build.yml
+
+### DEV CONFIGS  Uncomment if you want to use in dev mode
+
+# COMPOSE_FILE=${COMPOSE_FILE}:docker-compose-dev.yml
+
+# Should not be set on first launch but can be set to true afterward to gain time.
+# SKIP_POPULATE_DB=true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GEONATURE_BACKEND_IMAGE=ghcr.io/pnx-si/geonature-backend:2.17.1
+          build-args: GEONATURE_BACKEND_WHEELS_IMAGE=ghcr.io/pnx-si/geonature-backend:2.17.1-wheels
 
   frontend:
     name: Build geonature frontend docker image
@@ -88,4 +88,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GEONATURE_FRONTEND_IMAGE=ghcr.io/pnx-si/geonature-frontend:2.17.1
+          build-args: |
+            GEONATURE_FRONTEND_SOURCE_IMAGE=ghcr.io/pnx-si/geonature-frontend:2.17.1-source
+            GEONATURE_FRONTEND_NGINX_IMAGE=ghcr.io/pnx-si/geonature-frontend:2.17.1-nginx

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 	build/build.sh
 
 dev: dev_init
-	COMPOSE_FILE=docker-compose.yml:docker-compose-dev.yml docker compose up -d --force-recreate
+	COMPOSE_FILE=docker-compose.yml:docker-compose-dev.yml docker compose up -d
 	source .env; echo "Services de developpement lancés, vous pouvez y acceder sur : https://$${HOST}$${GEONATURE_FRONTEND_PREFIX}"
 
 prod:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ launch:
 
 dev_init:
 	./init-config.sh
-	jq '.projects.geonature.architect.build.configurations.development += {"baseHref": "/geonature/"}' sources/GeoNature/frontend/angular.json > angular.json.tmp && mv angular.json.tmp sources/GeoNature/frontend/angular.json # Pas une super pratique mais pas d'autre solution pour le moment
+	source .env; echo $${GEONATURE_FRONTEND_PREFIX}; jq ".projects.geonature.architect.build.configurations.development += {\"baseHref\": \"$${GEONATURE_FRONTEND_PREFIX}/\"}" sources/GeoNature/frontend/angular.json > angular.json.tmp && mv angular.json.tmp sources/GeoNature/frontend/angular.json # Pas une super pratique mais pas d'autre solution pour le moment
 	source .env; echo "{\"API_ENDPOINT\":\"//localhost$${GEONATURE_BACKEND_PREFIX}\"}" > sources/GeoNature/frontend/src/assets/config.json
 
 submodule_init:

--- a/build/Dockerfile-geonature-backend
+++ b/build/Dockerfile-geonature-backend
@@ -1,4 +1,4 @@
-ARG GEONATURE_BACKEND_IMAGE="ghcr.io/pnx-si/geonature-backend:latest"
+ARG GEONATURE_BACKEND_WHEELS_IMAGE=geonature_backend_wheels_image
 
 FROM python:3.11-bookworm AS build
 
@@ -22,7 +22,7 @@ WORKDIR /build/
 COPY ./sources/gn_module_monitoring .
 RUN python setup.py bdist_wheel
 
-FROM ${GEONATURE_BACKEND_IMAGE}-wheels AS base_env
+FROM ${GEONATURE_BACKEND_WHEELS_IMAGE} AS base_env
 WORKDIR /dist/geonature
 RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=cache,target=/var/lib/apt \

--- a/build/Dockerfile-geonature-frontend
+++ b/build/Dockerfile-geonature-frontend
@@ -1,7 +1,9 @@
-# syntax=docker/dockerfile:1.2
+# syntax=docker/dockerfile:1.4
 
-ARG GEONATURE_FRONTEND_IMAGE
-FROM ${GEONATURE_FRONTEND_IMAGE}-source AS source-extra
+ARG GEONATURE_FRONTEND_SOURCE_IMAGE=geonature_frontend_source_image
+ARG GEONATURE_FRONTEND_NGINX_IMAGE=geonature_frontend_nginx_image
+
+FROM ${GEONATURE_FRONTEND_SOURCE_IMAGE} AS source-extra
 
 WORKDIR /build/external_modules/exports
 COPY ./sources/gn_module_export/frontend/ .
@@ -31,6 +33,6 @@ FROM source-extra AS build-extra
 WORKDIR /build/
 RUN npm run build
 
-FROM ${GEONATURE_FRONTEND_IMAGE}-nginx AS prod-extra
+FROM ${GEONATURE_FRONTEND_NGINX_IMAGE} AS prod-extra
 
 COPY --from=build-extra /build/dist /usr/share/nginx/html

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,33 +2,18 @@
 
 set -x
 set -o nounset
-# todo delete this file ? Unless we want people to be able to build without launching compose
-# Buildkit by default since 2023, we don't need to specify it no more ? Same thing with compose that use it by default
-# now
-export COMPOSE_DOCKER_CLI_BUILD=1
-export DOCKER_BUILDKIT=1
-source .env
-# GN BACKEND WHEELS
-docker build -f sources/GeoNature/backend/Dockerfile -t ${GEONATURE_BACKEND_IMAGE}-wheels --target=wheels sources/GeoNature/
 
-# GN BACKEND EXTRA
-docker build \
-  --build-arg GEONATURE_BACKEND_IMAGE=${GEONATURE_BACKEND_IMAGE} \
-  -f ./build/Dockerfile-geonature-backend \
-  -t ${GEONATURE_BACKEND_EXTRA_IMAGE} .
+# It is necessary to build base-* images before building final images, and compose does not support build
+# dependencies yet (solved with additional_contexts in compose 2.36.2 - not in Debian 13).
 
-# GN FRONTEND SOURCE
-docker build -f sources/GeoNature/frontend/Dockerfile -t ${GEONATURE_FRONTEND_IMAGE}-source --target=source sources/GeoNature/
+# docker-compose-build must come first, as dev file (if present in COMPOSE_FILE) override build sections
+export COMPOSE_FILE=docker-compose-build.yml:$(docker compose config --environment | grep COMPOSE_FILE || echo "docker-compose.yml")
 
-# GN FRONTEND NGINX
-docker build -f sources/GeoNature/frontend/Dockerfile -t ${GEONATURE_FRONTEND_IMAGE}-nginx --target=prod-base sources/GeoNature/
+docker compose build base-backend
+docker compose build geonature-install-db # requires base-backend
 
-# GN FRONTEND EXTRA
-docker build \
-    --build-arg GEONATURE_FRONTEND_IMAGE=${GEONATURE_FRONTEND_IMAGE} \
-    -f ./build/Dockerfile-geonature-frontend \
-    -t ${GEONATURE_FRONTEND_EXTRA_IMAGE} .
+docker compose build base-frontend-source
+docker compose build base-frontend-nginx # FIXME: not required in dev mode
+docker compose build geonature-frontend  # requires base-frontend-source and base-frontend-nginx
 
-
-# UsersHub
-docker build -f sources/UsersHub/Dockerfile -t ${USERSHUB_IMAGE} --target=prod sources/UsersHub/
+docker compose build usershub

--- a/build/dev/Dockerfile-geonature-backend
+++ b/build/dev/Dockerfile-geonature-backend
@@ -1,6 +1,6 @@
-ARG GEONATURE_BACKEND_IMAGE="ghcr.io/pnx-si/geonature-backend-local:latest"
+ARG GEONATURE_BACKEND_WHEELS_IMAGE=geonature_backend_wheels_image
 
-FROM ${GEONATURE_BACKEND_IMAGE}-wheels AS base_env
+FROM ${GEONATURE_BACKEND_WHEELS_IMAGE} AS base_env
 
 ARG UID=1000
 ARG GID=1000

--- a/docker-compose-build-deps.yml
+++ b/docker-compose-build-deps.yml
@@ -1,0 +1,12 @@
+services:
+  geonature-install-db:
+    build:
+      additional_contexts:
+         geonature_backend_wheels_image: "service:base-backend"
+
+  geonature-frontend:
+      build:
+        additional_contexts:
+          geonature_frontend_source_image: "service:base-frontend-source"
+          geonature_frontend_nginx_image: "service:base-frontend-nginx"
+

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,0 +1,45 @@
+services:
+  base-backend:
+    image: ${GEONATURE_BACKEND_IMAGE}-wheels
+    build:
+      context: sources/GeoNature
+      dockerfile: backend/Dockerfile
+      target: wheels
+    entrypoint: /bin/true
+
+  base-frontend-source:
+    image: ${GEONATURE_FRONTEND_IMAGE}-source
+    build:
+      context: sources/GeoNature
+      dockerfile: frontend/Dockerfile
+      target: source
+    entrypoint: /bin/true
+
+  base-frontend-nginx:
+    image: ${GEONATURE_FRONTEND_IMAGE}-nginx
+    build:
+      context: sources/GeoNature
+      dockerfile: frontend/Dockerfile
+      target: prod-base
+    entrypoint: /bin/true
+
+  usershub:
+    build:
+      target: prod
+      context: sources/UsersHub
+
+  geonature-install-db:
+    build:
+      context: .
+      dockerfile: build/Dockerfile-geonature-backend
+      target: prod-extra
+      args:
+          GEONATURE_BACKEND_IMAGE: ${GEONATURE_BACKEND_IMAGE}
+
+  geonature-frontend:
+      build:
+        context: .
+        dockerfile: build/Dockerfile-geonature-frontend
+        target: prod-extra
+        args:
+          GEONATURE_FRONTEND_IMAGE: ${GEONATURE_FRONTEND_IMAGE}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -35,9 +35,6 @@ services:
     entrypoint: /bin/true
   #------------------------------------Builds section end------------------------------------#
   geonature-install-db:
-    depends_on:
-      base-backend:
-        condition: service_completed_successfully
     build:
       dockerfile: build/dev/Dockerfile-geonature-backend
       args:
@@ -47,9 +44,6 @@ services:
       - ./sources/GeoNature:/sources/GeoNature
 
   geonature-backend:
-    depends_on:
-      base-backend:
-        condition: service_completed_successfully
     volumes:
       - ./sources/GeoNature:/sources/GeoNature
       - ./sources/gn_module_export:/sources/gn_module_export
@@ -57,9 +51,6 @@ services:
       - ./sources/gn_module_monitoring:/sources/gn_module_monitoring
 
   geonature-worker:
-    depends_on:
-      base-backend:
-        condition: service_completed_successfully
     volumes:
       - ./sources/GeoNature:/sources/GeoNature
       - ./sources/gn_module_export:/sources/gn_module_export
@@ -87,9 +78,6 @@ services:
       - "8080:8080"
 
   geonature-frontend:
-      depends_on:
-        base-frontend-source:
-          condition: service_completed_successfully
       build:
         context: .
         dockerfile: build/Dockerfile-geonature-frontend

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -24,16 +24,13 @@ services:
       dockerfile: frontend/Dockerfile
       target: prod-base
     entrypoint: /bin/true
+  #------------------------------------Builds section end------------------------------------#
 
-  userhub-build:
-    image: ${USERSHUB_IMAGE}
+  userhub:
     build:
       target: prod
       context: sources/UsersHub
-    volumes:
-      - ./config/usershub:/dist/config/
-    entrypoint: /bin/true
-  #------------------------------------Builds section end------------------------------------#
+
   geonature-install-db:
     build:
       dockerfile: build/dev/Dockerfile-geonature-backend

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -84,7 +84,7 @@ services:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entryPoints.web.address=:80"
-      - "--entryPoints.web.http.redirections.entrypoint.to=:${HTTPS_PORT}"
+      - "--entryPoints.web.http.redirections.entrypoint.to=:${HTTPS_PORT:-443}"
       - "--entryPoints.web.http.redirections.entrypoint.scheme=https"
       - "--entryPoints.websecure.address=:443"
       - "--certificatesResolvers.acme-resolver.acme.email=${ACME_EMAIL}"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -55,11 +55,6 @@ services:
       - ./sources/gn_module_export:/sources/gn_module_export
       - ./sources/gn_module_dashboard:/sources/gn_module_dashboard
       - ./sources/gn_module_monitoring:/sources/gn_module_monitoring
-    build:
-      dockerfile: build/dev/Dockerfile-geonature-backend
-      args:
-        UID: ${UID}
-        GID: ${GID}
 
   geonature-worker:
     depends_on:
@@ -70,8 +65,6 @@ services:
       - ./sources/gn_module_export:/sources/gn_module_export
       - ./sources/gn_module_dashboard:/sources/gn_module_dashboard
       - ./sources/gn_module_monitoring:/sources/gn_module_monitoring
-    build:
-      dockerfile: build/dev/Dockerfile-geonature-backend
     command: watchmedo auto-restart --directory=/sources/GeoNature --pattern=*.py --recursive -- celery -A geonature.celery_app:app worker --beat --schedule-filename=/dist/media/celerybeat-schedule.db
 
   postgres:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,42 +1,8 @@
 services:
-
-  #------------------------------------Builds section start-----------------------------------#
-  base-backend:
-    image: ${GEONATURE_BACKEND_IMAGE}-wheels
-    build:
-      context: sources/GeoNature
-      dockerfile: backend/Dockerfile
-      target: wheels
-    entrypoint: /bin/true
-
-  base-frontend-source:
-    image: ${GEONATURE_FRONTEND_IMAGE}-source
-    build:
-      context: sources/GeoNature
-      dockerfile: frontend/Dockerfile
-      target: source
-    entrypoint: /bin/true
-
-  base-frontend-nginx:
-    image: ${GEONATURE_FRONTEND_IMAGE}-nginx
-    build:
-      context: sources/GeoNature
-      dockerfile: frontend/Dockerfile
-      target: prod-base
-    entrypoint: /bin/true
-  #------------------------------------Builds section end------------------------------------#
-
-  userhub:
-    build:
-      target: prod
-      context: sources/UsersHub
-
   geonature-install-db:
     build:
       dockerfile: build/dev/Dockerfile-geonature-backend
-      args:
-        UID: ${UID}
-        GID: ${GID}
+      target: base_env
     volumes:
       - ./sources/GeoNature:/sources/GeoNature
 
@@ -54,6 +20,10 @@ services:
       - ./sources/gn_module_dashboard:/sources/gn_module_dashboard
       - ./sources/gn_module_monitoring:/sources/gn_module_monitoring
     command: watchmedo auto-restart --directory=/sources/GeoNature --pattern=*.py --recursive -- celery -A geonature.celery_app:app worker --beat --schedule-filename=/dist/media/celerybeat-schedule.db
+
+  usershub:
+    build:
+      target: dev
 
   postgres:
     ports:
@@ -76,11 +46,7 @@ services:
 
   geonature-frontend:
       build:
-        context: .
-        dockerfile: build/Dockerfile-geonature-frontend
         target: dev-extra
-        args:
-          GEONATURE_FRONTEND_IMAGE: ${GEONATURE_FRONTEND_IMAGE}
       volumes:
         - ./sources/GeoNature/frontend:/build
         - ./sources/gn_module_dashboard/frontend:/build/external_modules/dashboard

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -7,7 +7,7 @@ services:
       context: sources/GeoNature
       dockerfile: backend/Dockerfile
       target: wheels
-    entrypoint: /bin/bash -c exit
+    entrypoint: /bin/true
 
   base-frontend-source:
     image: ${GEONATURE_FRONTEND_IMAGE}-source
@@ -15,7 +15,7 @@ services:
       context: sources/GeoNature
       dockerfile: frontend/Dockerfile
       target: source
-    entrypoint: /bin/bash -c exit
+    entrypoint: /bin/true
 
   base-frontend-nginx:
     image: ${GEONATURE_FRONTEND_IMAGE}-nginx
@@ -23,7 +23,7 @@ services:
       context: sources/GeoNature
       dockerfile: frontend/Dockerfile
       target: prod-base
-    entrypoint: /bin/sh -c exit
+    entrypoint: /bin/true
 
   userhub-build:
     image: ${USERSHUB_IMAGE}
@@ -32,7 +32,7 @@ services:
       context: sources/UsersHub
     volumes:
       - ./config/usershub:/dist/config/
-    entrypoint: /bin/sh -c exit
+    entrypoint: /bin/true
   #------------------------------------Builds section end------------------------------------#
   geonature-install-db:
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,10 @@ services:
     command:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
-      - "--entryPoints.web.address=:80"
-      - "--entryPoints.web.http.redirections.entrypoint.to=:${HTTPS_PORT}"
+      - "--entryPoints.web.address=:${HTTP_PORT:-80}"
+      - "--entryPoints.web.http.redirections.entrypoint.to=:${HTTPS_PORT:-443}"
       - "--entryPoints.web.http.redirections.entrypoint.scheme=https"
-      - "--entryPoints.websecure.address=:443"
+      - "--entryPoints.websecure.address=:${HTTPS_PORT:-443}"
       - "--certificatesResolvers.acme-resolver.acme.email=${ACME_EMAIL}"
       - "--certificatesResolvers.acme-resolver.acme.storage=/etc/traefik/certs/acme.json"
       - "--certificatesResolvers.acme-resolver.acme.tlsChallenge=true"
@@ -91,6 +91,8 @@ services:
           "${POSTGRES_USER}",
           "-h",
           "localhost",
+          "-p",
+          "${POSTGRES_PORT}",
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
(voir juste le dernier commit)
Ajout des dépendances de build via `additional_contexts`. Ceci permet de build via `docker compose build` et sans nécessiter le script `build.sh`.

Cette fonctionnalité est correctement supportée par docker compose >= v2.36.2. Pour rester compatible avec la version de compose fournit dans les dépôts de Debian 13, les `additional_contexts` ont été placé dans `docker-compose-build-deps.yml`.

À noter qu’il est facile d’avoir un compose à jour en rajoutant les dépôts de docker à ses sources apt, c’est même ce qui est préconisé dans le guide d’installation de docker : https://docs.docker.com/engine/install/debian/